### PR TITLE
Add Tkinter shogi app scaffold

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,26 @@
+name: CI
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+      - name: Ruff
+        run: ruff .
+      - name: Black
+        run: black --check .
+      - name: Mypy
+        run: mypy src
+      - name: Pytest
+        run: pytest

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+__pycache__/
+*.pyc
+.venv/

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2024
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,5 @@
+run:
+	PYTHONPATH=src python -m shogi_app.app
+
+test:
+	PYTHONPATH=src pytest

--- a/README.md
+++ b/README.md
@@ -1,3 +1,35 @@
-shogi-app
+# Shogi App
 
-This repository contains sample code for a Shogi application.
+Simple local two-player shogi application built with Tkinter and [python-shogi](https://github.com/niklasf/python-shogi).
+
+## Setup
+
+```bash
+python -m venv .venv
+source .venv/bin/activate
+pip install -r requirements.txt
+```
+
+## Run
+
+```bash
+make run
+```
+
+## Test
+
+```bash
+make test
+```
+
+## Usage
+
+- Click a piece to see its legal moves.
+- Click a highlighted square to move.
+- Captured pieces appear above/below the board; click one and then a square to drop.
+- Promotion is prompted when applicable.
+- Positions can be saved/loaded in SFEN, KIF, or CSA formats from the *File* menu.
+
+## License
+
+[MIT](LICENSE)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,41 @@
+[build-system]
+requires = ["setuptools>=67", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "shogi-app"
+version = "0.1.0"
+description = "Simple Tkinter shogi application"
+authors = [{name = "Example", email = "example@example.com"}]
+readme = "README.md"
+requires-python = ">=3.11"
+dependencies = [
+    "python-shogi",
+]
+
+[project.optional-dependencies]
+dev = [
+    "pytest",
+    "ruff",
+    "black",
+    "mypy",
+]
+
+[tool.black]
+line-length = 88
+target-version = ["py311"]
+
+[tool.ruff]
+line-length = 88
+select = ["E", "F", "B", "I"]
+
+[tool.mypy]
+python_version = "3.11"
+disallow_untyped_defs = true
+warn_return_any = true
+no_implicit_optional = true
+ignore_missing_imports = true
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+pythonpath = ["src"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,5 @@
+python-shogi
+pytest
+ruff
+black
+mypy

--- a/src/shogi_app/__init__.py
+++ b/src/shogi_app/__init__.py
@@ -1,0 +1,6 @@
+"""Shogi application package."""
+
+from .logic import ShogiGame
+from .ui_tk import ShogiUI
+
+__all__ = ["ShogiGame", "ShogiUI"]

--- a/src/shogi_app/app.py
+++ b/src/shogi_app/app.py
@@ -1,0 +1,17 @@
+"""Entry point for running the Shogi application."""
+
+import tkinter as tk
+
+from .ui_tk import ShogiUI
+
+
+def main() -> None:
+    """Launch the Tkinter user interface."""
+
+    root = tk.Tk()
+    ShogiUI(root)
+    root.mainloop()
+
+
+if __name__ == "__main__":
+    main()

--- a/src/shogi_app/logic.py
+++ b/src/shogi_app/logic.py
@@ -1,0 +1,118 @@
+"""Game logic built on python-shogi."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import List, cast
+
+import shogi
+import shogi.CSA
+import shogi.KIF
+
+
+@dataclass
+class MoveOption:
+    """A legal move with optional promotion flag."""
+
+    move: shogi.Move
+    promotion: bool
+
+
+class ShogiGame:
+    """Wrapper around :class:`shogi.Board` to manage game state."""
+
+    def __init__(self, sfen: str | None = None) -> None:
+        self.board = shogi.Board(sfen) if sfen else shogi.Board()
+
+    def legal_moves_from(self, square: int) -> List[MoveOption]:
+        """Return legal moves originating from ``square``."""
+
+        return [
+            MoveOption(move=m, promotion=m.promotion)
+            for m in self.board.legal_moves
+            if m.from_square == square
+        ]
+
+    def push(self, move: shogi.Move) -> None:
+        """Push ``move`` onto the board."""
+
+        self.board.push(move)
+
+    def push_usi(self, usi: str) -> bool:
+        """Push move described in USI notation if legal."""
+
+        mv = shogi.Move.from_usi(usi)
+        if mv in self.board.legal_moves:
+            self.board.push(mv)
+            return True
+        return False
+
+    def is_checkmate(self) -> bool:
+        """Return ``True`` if the side to move is checkmated."""
+
+        return bool(self.board.is_checkmate())
+
+    def is_repetition(self) -> bool:
+        """Return ``True`` if the position is fourfold repetition."""
+
+        return bool(self.board.is_fourfold_repetition())
+
+    def sfen(self) -> str:
+        """Return current position in SFEN."""
+
+        return cast(str, self.board.sfen())
+
+    def set_sfen(self, sfen: str) -> None:
+        """Load position from SFEN string."""
+
+        self.board.set_sfen(sfen)
+
+    def save_sfen(self, path: str | Path) -> None:
+        """Save current position to ``path`` in SFEN format."""
+
+        Path(path).write_text(self.board.sfen(), encoding="utf8")
+
+    def load_sfen(self, path: str | Path) -> None:
+        """Load position from ``path`` in SFEN format."""
+
+        sfen = Path(path).read_text(encoding="utf8").strip()
+        self.board.set_sfen(sfen)
+
+    def save_kif(self, path: str | Path) -> None:
+        """Save current position to ``path`` in KIF format."""
+
+        Path(path).write_text(self.board.kif_dump(), encoding="utf8")
+
+    def load_kif(self, path: str | Path) -> None:
+        """Load position from ``path`` in KIF format."""
+
+        parser = shogi.KIF.Parser()
+        records = parser.parse_file(Path(path))
+        record = records[0]
+        board = record["initial_position"]
+        for mv in record["moves"]:
+            board.push(mv["move"])
+        self.board = board
+
+    def save_csa(self, path: str | Path) -> None:
+        """Save current position to ``path`` in CSA format."""
+
+        Path(path).write_text(self.board.csa_dump(), encoding="utf8")
+
+    def load_csa(self, path: str | Path) -> None:
+        """Load position from ``path`` in CSA format."""
+
+        parser = shogi.CSA.Parser()
+        records = parser.parse_file(Path(path))
+        record = records[0]
+        board = record["initial_position"]
+        for mv in record["moves"]:
+            board.push(mv["move"])
+        self.board = board
+
+    def pieces_in_hand(self, color: shogi.Color) -> dict[int, int]:
+        """Return pieces in hand for ``color``."""
+
+        counts = self.board.pieces_in_hand[color]
+        return {pt: counts[pt] for pt in range(1, len(counts)) if counts[pt]}

--- a/src/shogi_app/ui_tk.py
+++ b/src/shogi_app/ui_tk.py
@@ -1,0 +1,228 @@
+"""Tkinter based user interface for the shogi game."""
+
+from __future__ import annotations
+
+import tkinter as tk
+from functools import partial
+from tkinter import filedialog, messagebox
+from typing import Optional
+
+import shogi
+
+from .logic import ShogiGame
+
+SQUARE_SIZE = 60
+BOARD_SIZE = SQUARE_SIZE * 9
+PIECE_SYMBOLS = {
+    shogi.PAWN: "歩",
+    shogi.LANCE: "香",
+    shogi.KNIGHT: "桂",
+    shogi.SILVER: "銀",
+    shogi.GOLD: "金",
+    shogi.BISHOP: "角",
+    shogi.ROOK: "飛",
+    shogi.KING: "王",
+    shogi.PRO_PAWN: "と",
+    shogi.PRO_LANCE: "成香",
+    shogi.PRO_KNIGHT: "成桂",
+    shogi.PRO_SILVER: "成銀",
+    shogi.HORSE: "馬",
+    shogi.DRAGON: "龍",
+}
+
+
+class ShogiUI:
+    """Tkinter based UI to interact with :class:`ShogiGame`."""
+
+    def __init__(self, root: tk.Tk) -> None:
+        self.root = root
+        self.game = ShogiGame()
+        self.selected_square: Optional[int] = None
+        self.drop_piece_type: Optional[int] = None
+
+        self.root.title("Shogi App")
+        self._build_menu()
+
+        self.top_hand = tk.Frame(root)
+        self.top_hand.pack()
+        self.canvas = tk.Canvas(
+            root, width=BOARD_SIZE, height=BOARD_SIZE, bg="saddlebrown"
+        )
+        self.canvas.pack()
+        self.bottom_hand = tk.Frame(root)
+        self.bottom_hand.pack()
+        self.info = tk.Label(root, text="Turn: Black")
+        self.info.pack()
+
+        self.canvas.bind("<Button-1>", self.on_board_click)
+        self.draw_board()
+        self.update_hands()
+
+    # Menu -----------------------------------------------------------------
+    def _build_menu(self) -> None:
+        menu = tk.Menu(self.root)
+        file_menu = tk.Menu(menu, tearoff=0)
+        file_menu.add_command(label="Save SFEN", command=self.save_sfen)
+        file_menu.add_command(label="Load SFEN", command=self.load_sfen)
+        file_menu.add_command(label="Save KIF", command=self.save_kif)
+        file_menu.add_command(label="Load KIF", command=self.load_kif)
+        file_menu.add_command(label="Save CSA", command=self.save_csa)
+        file_menu.add_command(label="Load CSA", command=self.load_csa)
+        menu.add_cascade(label="File", menu=file_menu)
+        self.root.config(menu=menu)
+
+    # Board ----------------------------------------------------------------
+    def draw_board(self) -> None:
+        self.canvas.delete("all")
+        for sq in shogi.SQUARES:
+            file = shogi.square_file(sq)
+            rank = shogi.square_rank(sq)
+            x1 = file * SQUARE_SIZE
+            y1 = (8 - rank) * SQUARE_SIZE
+            x2 = x1 + SQUARE_SIZE
+            y2 = y1 + SQUARE_SIZE
+            color = "burlywood" if (file + rank) % 2 == 0 else "#DEB887"
+            self.canvas.create_rectangle(x1, y1, x2, y2, fill=color)
+            piece = self.game.board.piece_at(sq)
+            if piece:
+                text = PIECE_SYMBOLS.get(piece.piece_type, piece.symbol().upper())
+                if piece.color == shogi.WHITE:
+                    text = text[::-1] if len(text) > 1 else text
+                    fill = "red"
+                else:
+                    fill = "black"
+                self.canvas.create_text(
+                    x1 + SQUARE_SIZE / 2,
+                    y1 + SQUARE_SIZE / 2,
+                    text=text,
+                    font=("TakaoPGothic", 20),
+                    tags="piece",
+                    fill=fill,
+                )
+
+        if self.selected_square is not None:
+            for opt in self.game.legal_moves_from(self.selected_square):
+                file = shogi.square_file(opt.move.to_square)
+                rank = shogi.square_rank(opt.move.to_square)
+                x1 = file * SQUARE_SIZE
+                y1 = (8 - rank) * SQUARE_SIZE
+                x2 = x1 + SQUARE_SIZE
+                y2 = y1 + SQUARE_SIZE
+                self.canvas.create_rectangle(
+                    x1,
+                    y1,
+                    x2,
+                    y2,
+                    outline="blue",
+                    width=3,
+                    tags="highlight",
+                )
+
+    def on_board_click(self, event: tk.Event[tk.Canvas]) -> None:
+        file = int(event.x // SQUARE_SIZE)
+        rank = 8 - int(event.y // SQUARE_SIZE)
+        square = shogi.square(file, rank)
+        piece = self.game.board.piece_at(square)
+
+        if self.drop_piece_type is not None:
+            symbol = shogi.PIECE_SYMBOLS[self.drop_piece_type]
+            move = shogi.Move.from_usi(f"{symbol}*{shogi.SQUARE_NAMES[square]}")
+            if move in self.game.board.legal_moves:
+                self.game.push(move)
+                self.drop_piece_type = None
+                self.after_move()
+            return
+
+        if self.selected_square is None:
+            if piece and piece.color == self.game.board.turn:
+                self.selected_square = square
+                self.draw_board()
+            return
+
+        if square == self.selected_square:
+            self.selected_square = None
+            self.draw_board()
+            return
+
+        moves = [
+            m
+            for m in self.game.board.legal_moves
+            if m.from_square == self.selected_square and m.to_square == square
+        ]
+        if not moves:
+            self.selected_square = None
+            self.draw_board()
+            return
+        if len(moves) == 1:
+            self.game.push(moves[0])
+        else:
+            if messagebox.askyesno("Promotion", "Promote?"):
+                move = [m for m in moves if m.promotion][0]
+            else:
+                move = [m for m in moves if not m.promotion][0]
+            self.game.push(move)
+        self.selected_square = None
+        self.after_move()
+
+    def after_move(self) -> None:
+        if self.game.is_checkmate():
+            messagebox.showinfo("Game Over", "Checkmate")
+        elif self.game.is_repetition():
+            messagebox.showinfo("Game Over", "Repetition")
+        self.draw_board()
+        self.update_hands()
+        turn = "Black" if self.game.board.turn == shogi.BLACK else "White"
+        self.info.config(text=f"Turn: {turn}")
+
+    # Hands ---------------------------------------------------------------
+    def update_hands(self) -> None:
+        for frame, color in (
+            (self.top_hand, shogi.WHITE),
+            (self.bottom_hand, shogi.BLACK),
+        ):
+            for widget in frame.winfo_children():
+                widget.destroy()
+            pieces = self.game.pieces_in_hand(color)
+            for pt, count in pieces.items():
+                txt = f"{PIECE_SYMBOLS.get(pt, '?')}x{count}"
+                btn = tk.Button(frame, text=txt, command=partial(self.select_drop, pt))
+                btn.pack(side=tk.LEFT)
+
+    def select_drop(self, piece_type: int) -> None:
+        self.drop_piece_type = piece_type
+        self.selected_square = None
+        self.draw_board()
+
+    # File operations -----------------------------------------------------
+    def save_sfen(self) -> None:
+        path = filedialog.asksaveasfilename(defaultextension=".sfen")
+        if path:
+            self.game.save_sfen(path)
+
+    def load_sfen(self) -> None:
+        path = filedialog.askopenfilename(filetypes=[("SFEN", "*.sfen"), ("All", "*")])
+        if path:
+            self.game.load_sfen(path)
+            self.after_move()
+
+    def save_kif(self) -> None:
+        path = filedialog.asksaveasfilename(defaultextension=".kif")
+        if path:
+            self.game.save_kif(path)
+
+    def load_kif(self) -> None:
+        path = filedialog.askopenfilename(filetypes=[("KIF", "*.kif"), ("All", "*")])
+        if path:
+            self.game.load_kif(path)
+            self.after_move()
+
+    def save_csa(self) -> None:
+        path = filedialog.asksaveasfilename(defaultextension=".csa")
+        if path:
+            self.game.save_csa(path)
+
+    def load_csa(self) -> None:
+        path = filedialog.askopenfilename(filetypes=[("CSA", "*.csa"), ("All", "*")])
+        if path:
+            self.game.load_csa(path)
+            self.after_move()

--- a/tests/test_logic.py
+++ b/tests/test_logic.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from shogi_app.logic import ShogiGame
+
+
+def test_legal_moves() -> None:
+    game = ShogiGame()
+    assert len(list(game.board.legal_moves)) == 30
+
+
+def test_sfen_io(tmp_path: Path) -> None:
+    game = ShogiGame()
+    assert game.push_usi("7g7f")
+    path = tmp_path / "pos.sfen"
+    game.save_sfen(path)
+    game2 = ShogiGame()
+    game2.load_sfen(path)
+    assert game.sfen() == game2.sfen()
+
+
+def test_repetition() -> None:
+    game = ShogiGame("8k/9/9/9/9/9/9/9/K8 b - 1")
+    for _ in range(4):
+        assert game.push_usi("1i2i")
+        assert game.push_usi("9a8a")
+        assert game.push_usi("2i1i")
+        assert game.push_usi("8a9a")
+    assert game.is_repetition()


### PR DESCRIPTION
## Summary
- scaffold shogi application using Tkinter and python-shogi
- include game logic, GUI, and tests
- add CI, formatting, and linting configuration

## Testing
- `ruff check .`
- `black --check .`
- `mypy src`
- `make test` *(fails: ModuleNotFoundError: No module named 'shogi')*
- `make run` *(fails: ModuleNotFoundError: No module named 'shogi')*


------
https://chatgpt.com/codex/tasks/task_e_68b474fdb628832c9f7067e43eb08538